### PR TITLE
Added some for fields perquisite for ticketing system

### DIFF
--- a/api/src/main/java/com/community/api/endpoint/serviceProvider/ServiceProviderEntity.java
+++ b/api/src/main/java/com/community/api/endpoint/serviceProvider/ServiceProviderEntity.java
@@ -236,11 +236,14 @@ public class ServiceProviderEntity  {
     @OneToMany(mappedBy = "service_provider", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<QualificationDetails> qualificationDetailsList;
 
+    @Column(name="is_active")
+    private Boolean isActive;
 
+    @Column(name="maximum_ticket_size")
+    private Integer maximumTicketSize;
 
-
-
-
+    @Column(name="maximum_binding_size")
+    private Integer maximumBindingSize;
 
 }
 

--- a/api/src/main/java/com/community/api/entity/ServiceProviderRank.java
+++ b/api/src/main/java/com/community/api/entity/ServiceProviderRank.java
@@ -26,6 +26,11 @@ public class ServiceProviderRank
     private String rank_description;
     private String created_at,updated_at,created_by;
 
+    @Column(name="maximum_ticket_size")
+    private Integer maximumTicketSize;
+
+    @Column(name="maximum_binding_size")
+    private Integer maximumBindingSize;
 
 }
 

--- a/api/src/main/java/com/community/api/services/CommandLineService.java
+++ b/api/src/main/java/com/community/api/services/CommandLineService.java
@@ -348,14 +348,14 @@ public class CommandLineService implements CommandLineRunner {
         count = entityManager.createQuery("SELECT count(e) FROM ServiceProviderRank e", Long.class).getSingleResult();
 
         if (count == 0) {
-            entityManager.persist(new ServiceProviderRank(1L, "1a", "The PROFESSIONAL service provider's score is between 75-100 points", now, now, "SUPER_ADMIN"));
-            entityManager.persist(new ServiceProviderRank(2L, "1b", "The PROFESSIONAL service provider's score is between 50-75 points", now, now, "SUPER_ADMIN"));
-            entityManager.persist(new ServiceProviderRank(3L, "1c", "The PROFESSIONAL service provider's score is between 25-50 points", now, now, "SUPER_ADMIN"));
-            entityManager.persist(new ServiceProviderRank(4L, "1d", "The PROFESSIONAL service provider's score is between 0-25 points", now, now, "SUPER_ADMIN"));
-            entityManager.persist(new ServiceProviderRank(5L, "2a", "The INDIVIDUAL service provider's score is between 75-100 points", now, now, "SUPER_ADMIN"));
-            entityManager.persist(new ServiceProviderRank(6L, "2b", "The INDIVIDUAL service provider's score is between 50-75 points", now, now, "SUPER_ADMIN"));
-            entityManager.persist(new ServiceProviderRank(7L, "2c", "The INDIVIDUAL service provider's score is between 25-50 points", now, now, "SUPER_ADMIN"));
-            entityManager.persist(new ServiceProviderRank(8L, "2d", "The INDIVIDUAL service provider's score is between 0-25 points", now, now, "SUPER_ADMIN"));
+            entityManager.persist(new ServiceProviderRank(1L, "1a", "The PROFESSIONAL service provider's score is between 75-100 points", now, now, "SUPER_ADMIN", 12, 50));
+            entityManager.persist(new ServiceProviderRank(2L, "1b", "The PROFESSIONAL service provider's score is between 50-75 points", now, now, "SUPER_ADMIN", 6, 25));
+            entityManager.persist(new ServiceProviderRank(3L, "1c", "The PROFESSIONAL service provider's score is between 25-50 points", now, now, "SUPER_ADMIN", 4,17));
+            entityManager.persist(new ServiceProviderRank(4L, "1d", "The PROFESSIONAL service provider's score is between 0-25 points", now, now, "SUPER_ADMIN", 3, 13));
+            entityManager.persist(new ServiceProviderRank(5L, "2a", "The INDIVIDUAL service provider's score is between 75-100 points", now, now, "SUPER_ADMIN", 6, 25));
+            entityManager.persist(new ServiceProviderRank(6L, "2b", "The INDIVIDUAL service provider's score is between 50-75 points", now, now, "SUPER_ADMIN", 3, 13));
+            entityManager.persist(new ServiceProviderRank(7L, "2c", "The INDIVIDUAL service provider's score is between 25-50 points", now, now, "SUPER_ADMIN", 2, 8));
+            entityManager.persist(new ServiceProviderRank(8L, "2d", "The INDIVIDUAL service provider's score is between 0-25 points", now, now, "SUPER_ADMIN", 2, 6));
         }
 
          count = entityManager.createQuery("SELECT count(e) FROM ScoringCriteria e", Long.class).getSingleResult();


### PR DESCRIPTION
### Added field 
In **ServiceProviderEntity** class 
isActive (boolean),
maximumTicketSize(Integer),
maximumBindingSize(Integer)

and **ServiceProviderRank** class
maximumTicketSize(Integer),
maximumBindingSize(Integer)

also added some static data in the service_provider_rank equivalent to ServiceProviderRank
### For Maximum Binding Size
User: 1a
Ranking: 1a
Ratio between SP: 1:1
Max Binding Size per SP: 50
User: 2a
Ranking: 1a:2a
Ratio between SP: 1:2
Max Binding Size per SP: 25
User: 1b
Ranking: 1a:1b
Ratio between SP: 1:2
Max Binding Size per SP: 25
User: 2b
Ranking: 2a:2b
Ratio between SP: 1:2
Max Binding Size per SP: 13
User: 1c
Ranking: 1a:1c
Ratio between SP: 1:3
Max Binding Size per SP: 17
User: 2c
Ranking: 2a:2c
Ratio between SP: 1:3
Max Binding Size per SP: 8
User: 1d
Ranking: 1a:1d
Ratio between SP: 1:4
Max Binding Size per SP: 13
User: 2d
Ranking: 2a:2d
Ratio between SP: 1:4
Max Binding Size per SP: 6

### For Maximum Ticket Size
for max_ticket_size
User: 1a
Ranking: 1a
Ratio between SP: 1:1
Tickets allocated as per max ticket size per clock: 12
User: 2a
Ranking: 1a:2a
Ratio between SP: 1:2
Tickets allocated as per max ticket size per clock: 6
User: 1b
Ranking: 1a:1b
Ratio between SP: 1:2
Tickets allocated as per max ticket size per clock: 6
User: 2b
Ranking: 2a:2b
Ratio between SP: 1:2
Tickets allocated as per max ticket size per clock: 3
User: 1c
Ranking: 1a:1c
Ratio between SP: 1:3
Tickets allocated as per max ticket size per clock: 4
User: 2c
Ranking: 2a:2c
Ratio between SP: 1:3
Tickets allocated as per max ticket size per clock: 2
User: 1d
Ranking: 1a:1d
Ratio between SP: 1:4
Tickets allocated as per max ticket size per clock: 3
User: 2d
Ranking: 2a:2d
Ratio between SP: 1:4
Tickets allocated as per max ticket size per clock: 2