### PR TITLE
Admin login bug is resolved

### DIFF
--- a/api/src/main/java/com/community/api/entity/CustomAdmin.java
+++ b/api/src/main/java/com/community/api/entity/CustomAdmin.java
@@ -29,6 +29,7 @@ public class CustomAdmin
     @Size(min = 9, max = 13)
     private String mobileNumber;
     private String country_code;
+    @Column(columnDefinition = "TEXT")
     private String token;
     private int signedUp=0;
     private String created_at,updated_at,created_by, modified_by;


### PR DESCRIPTION
The issue was arising because the size of token is greater than expected so it was showing "value is too long" error on console So I  changed the column definition to accept large string also